### PR TITLE
Build on Travis against Node 0.10, 4 and 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ node_js:
   - "6"
 services:
   - redis-server
+script:
+  - npm run lint
+  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
   - "0.10"
+  - "4"
+  - "6"
 services:
   - redis-server

--- a/README.md
+++ b/README.md
@@ -70,20 +70,7 @@ var client = redis.createClient(6379, 'localhost', {
 ### `key`
 
 The key is how requests are grouped for rate-limiting.
-Typically, this would be a user ID, a type of operation...
-There are several helpers built-in:
-
-```js
-// identify users by IP
-key: 'ip'
-
-// identify users by their IP network (255.255.255.0 mask)
-key: 'ip/32'
-
-// identify users by the X-Forwarded-For header
-// careful: this is just an HTTP header and can easily be spoofed
-key: 'x-forwarded-for'
-```
+Typically, this would be a user ID, a type of operation.
 
 You can also specify any custom function:
 
@@ -96,6 +83,12 @@ key: function(x) { return x.user.id + ':' + x.operation; }
 
 // rate limit everyone in the same bucket
 key: function(x) { return 'single-bucket'; }
+```
+
+You can also use the built-in `ip` shorthand, which gets the remote address from an HTTP request.
+
+```js
+key: 'ip'
 ```
 
 ### `window`
@@ -183,5 +176,4 @@ server.get(
   rateLimiter.middleware({redis: client, key: ipAndRoute, rate: '20/minute'}),
   controllerB
 );
-
 ```

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,6 +1,5 @@
 var assert  = require('assert');
 var moment  = require('moment');
-var ip      = require('ip');
 
 exports.canonical = function(opts) {
 
@@ -37,12 +36,8 @@ exports.canonical = function(opts) {
   return canon;
 };
 
-
 var keyShorthands = {
   'ip': function(req) {
     return req.connection.remoteAddress;
-  },
-  'ip/32': function (req) {
-    return ip.mask(req.connection.remoteAddress, '255.255.255.0') + '/32';
   }
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "test": "./node_modules/.bin/mocha"
   },
   "dependencies": {
-    "ip": "~1.1.2",
     "moment": "~2.12.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "main": "lib/index.js",
   "repository": "TabDigital/redis-rate-limiter",
   "scripts": {
-    "test": "./node_modules/.bin/mocha"
+    "lint": "require-lint",
+    "test": "mocha"
   },
   "dependencies": {
     "moment": "~2.12.0"
@@ -18,6 +19,7 @@
     "lodash": "~4.6.1",
     "mocha": "~2.4.5",
     "redis": "~2.6.0-0",
+    "require-lint": "^1.1.1",
     "should": "~8.3.0",
     "supertest": "~1.2.0"
   }

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -30,7 +30,14 @@ describe('Middleware', function() {
     });
 
     beforeEach(function(done) {
-      client.del('ratelimit:127.0.0.1', done);
+      // cleanup Redis keys
+      // TODO: cleanup is coupled to how the default "ip" shorthand works
+      var server = express();
+      server.get('/cleanup', function(req, res) {
+        client.del('ratelimit:' + req.connection.remoteAddress);
+        res.end();
+      });
+      supertest(server).get('/cleanup').end(done);
     });
 
     it('passes through under the limit', function(done) {

--- a/test/options.spec.js
+++ b/test/options.spec.js
@@ -29,18 +29,6 @@ describe('Options', function() {
       }).should.eql('1.2.3.4');
     });
 
-    it('can be the client IP/32 mask', function() {
-      var opts = options.canonical({
-        redis: {},
-        key: 'ip/32',
-        limit: 10,
-        window: 60
-      });
-      opts.key({
-        connection: { remoteAddress: '1.2.3.4' }
-      }).should.eql('1.2.3.0/32');
-    });
-
     it('fails for invalid keys', function() {
       (function() {
         var opts = options.canonical({

--- a/test/rate-limiter.spec.js
+++ b/test/rate-limiter.spec.js
@@ -2,6 +2,7 @@ var _            = require('lodash');
 var async        = require('async');
 var should       = require('should');
 var redis        = require('redis');
+var reset        = require('./reset');
 var rateLimiter  = require('../lib/rate-limiter');
 
 describe('Rate-limiter', function() {
@@ -17,11 +18,7 @@ describe('Rate-limiter', function() {
   });
 
   beforeEach(function(done) {
-    async.series([
-      client.del.bind(client, 'ratelimit:a'),
-      client.del.bind(client, 'ratelimit:b'),
-      client.del.bind(client, 'ratelimit:c')
-    ], done);
+    reset.allkeys(client, done);
   });
 
   it('calls back with the rate data', function(done) {

--- a/test/reset.js
+++ b/test/reset.js
@@ -1,0 +1,14 @@
+
+// Remove all rate-limiting keys from Redis
+// To clean up tests
+// Don't use in production because of bad O(n) performance
+// See: http://redis.io/commands/keys
+exports.allkeys = function(redisClient, done) {
+  redisClient.keys('ratelimit*:*', function(err, keys) {
+    if (err) return done();
+    if (keys.length === 0) return done();
+    redisClient.del.call(redisClient, keys, function(err) {
+      done();
+    });
+  });
+};


### PR DESCRIPTION
Updating to Node 4 and 6, seems to be failing... let's investigate.

Node 4+ seems to default to `IPv6` when using `req.connection.remoteAddress` which made the test cleanup phase fail. Fixes:
- improved (and simplified) test cleanup to remove all keys matching `ratelimit*`
- removed support for `ip/32` which was very badly named (thus assuming no one is using it), and doesn't work with IPv6 because of the netmask library we used
- with the above, removed unnecessary `ip` package
- add [require-lint](https://www.npmjs.com/package/require-lint) as part of the build
