### PR TITLE
adding support for dynamic rate limiting.

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -1,43 +1,59 @@
 var assert  = require('assert');
 var moment  = require('moment');
 
-exports.canonical = function(opts) {
-
-  var canon = {};
-
-  // Redis connection
-  assert.equal(typeof opts.redis, 'object', 'Invalid redis client');
-  canon.redis = opts.redis;
-
-  // Key function
-  if (typeof opts.key === 'function') canon.key = opts.key;
-  if (typeof opts.key === 'string')   canon.key = keyShorthands[opts.key];
-
-  // Rate shorthand
-  if (opts.rate) {
-    assert.equal(typeof opts.rate, 'string', 'Invalid rate: ' + opts.rate);
-    var match = opts.rate.match(/^(\d+)\s*\/\s*([a-z]+)$/);
-    assert.ok(match, 'Invalid rate: ' + opts.rate);
-    canon.limit = parseInt(match[1], 10);
-    canon.window = moment.duration(1, match[2]) / 1000;
-    assert.notEqual(canon.limit, 0,  'Invalid rate limit: ' + opts.rate);
-    assert.notEqual(canon.window, 0, 'Invalid rate window: ' + opts.rate);
-  }
-
-  // Limit + window
-  if (opts.limit)  canon.limit  = opts.limit;
-  if (opts.window) canon.window = opts.window;
-
-  // Check option types
-  assert.equal(typeof canon.key, 'function', 'Invalid key: ' + opts.key);
-  assert.equal(typeof canon.limit, 'number', 'Invalid limit: ' + canon.limit);
-  assert.equal(typeof canon.window, 'number', 'Invalid window: ' + canon.window);
-
-  return canon;
+var getMatches =  function(opts){
+  return getRate(opts).match(/^(\d+)\s*\/\s*([a-z]+)$/);
 };
 
 var keyShorthands = {
   'ip': function(req) {
     return req.connection.remoteAddress;
   }
+};
+
+var getRate = function(opts){
+  if(typeof opts.rate === 'function') return opts.rate();
+  return opts.rate;
+};
+
+var getLimit = function(opts){
+  if(getRate(opts)) return parseInt(getMatches(opts)[1], 10);
+  if(typeof opts.limit === 'function') return opts.limit();
+  return opts.limit;
+};
+
+var getWindow = function(opts){
+  if(getRate(opts)) return moment.duration(1, getMatches(opts)[2]) / 1000;
+  if(typeof opts.window === 'function') return opts.window();
+  return opts.window;
+};
+
+var getKey = function(opts){
+  if(typeof opts.key === 'function') return opts.key;
+  return keyShorthands[opts.key];
+};
+
+var validate = function(opts){
+  assert.equal(typeof opts.redis, 'object', 'Invalid redis client');
+  assert.equal(typeof getKey(opts), 'function', 'Invalid key: ' + opts.key);
+  if(opts.rate) assert.ok(getMatches(opts), 'Invalid rate: ' + getRate(opts));
+  assert.equal(typeof getLimit(opts), 'number', 'Invalid limit: ' + getLimit(opts));
+  assert.equal(typeof getWindow(opts), 'number', 'Invalid window: ' + getWindow(opts));
+  assert.notEqual(getLimit(opts), 0,  'Invalid rate limit: ' + getRate(opts));
+  assert.notEqual(getWindow(opts), 0, 'Invalid rate window: ' + getRate(opts));
+};
+
+canonical = function(opts) {
+  validate(opts);
+  return {
+    redis: opts.redis,
+    key: getKey(opts),
+    rate: getRate.bind(null, opts),
+    limit: getLimit.bind(null, opts),
+    window: getWindow.bind(null, opts)
+  };
+};
+
+module.exports = {
+  canonical: canonical
 };

--- a/lib/rate-limiter.js
+++ b/lib/rate-limiter.js
@@ -7,7 +7,7 @@ module.exports = function(opts) {
     var tempKey = 'ratelimittemp:' + key;
     var realKey = 'ratelimit:' + key;
     opts.redis.multi()
-         .setex(tempKey, opts.window, 0)
+         .setex(tempKey, opts.window(), 0)
          .renamenx(tempKey, realKey)
          .incr(realKey)
          .ttl(realKey)
@@ -16,15 +16,15 @@ module.exports = function(opts) {
              callback(err);
            } else {
              if (results[3] == -1) {  // automatically recover from possible race condition
-               opts.redis.expire(realKey,opts.window);
+               opts.redis.expire(realKey,opts.window());
              }
              var current = results[2];
              callback(null, {
                key: key,
                current: current,
-               limit: opts.limit,
-               window: opts.window,
-               over: (current > opts.limit)
+               limit: opts.limit(),
+               window: opts.window(),
+               over: (current > opts.limit())
              });
            }
          });

--- a/test/options.spec.js
+++ b/test/options.spec.js
@@ -8,7 +8,7 @@ describe('Options', function() {
     it('can specify a function', function() {
       var opts = options.canonical({
         redis: {},
-        key: function(req) { return req.id; },
+        key: function(req) {return req.id;},
         limit: 10,
         window: 60
       });
@@ -51,8 +51,19 @@ describe('Options', function() {
         limit: 10,   // 10 requests
         window: 60   // per 60 seconds
       });
-      opts.limit.should.eql(10);
-      opts.window.should.eql(60);
+      opts.limit().should.eql(10);
+      opts.window().should.eql(60);
+    });
+
+    it('should allow functions to get the limit', function() {
+      var opts = options.canonical({
+        redis: {},
+        key: 'ip',
+        limit: function(){return 10;},   // 10 requests
+        window: function(){return 60;}   // per 60 seconds
+      });
+      opts.limit().should.eql(10);
+      opts.window().should.eql(60);
     });
 
   });
@@ -65,8 +76,8 @@ describe('Options', function() {
         key: 'ip',
         rate: rate
       });
-      opts.limit.should.eql(limit, 'Wrong limit for rate ' + rate);
-      opts.window.should.eql(window, 'Wrong window for rate ' + rate);
+      opts.limit().should.eql(limit, 'Wrong limit for rate ' + rate);
+      opts.window().should.eql(window, 'Wrong window for rate ' + rate);
     }
 
     it('can use the full unit name (x/second)', function() {
@@ -74,6 +85,7 @@ describe('Options', function() {
       assertRate('100/minute', 100, 60);
       assertRate('1000/hour', 1000, 3600);
       assertRate('5000/day', 5000, 86400);
+      assertRate(function(){return '5000/day';}, 5000, 86400);
     });
 
     it('can use the short unit name (x/s)', function() {
@@ -81,6 +93,7 @@ describe('Options', function() {
       assertRate('100/m', 100, 60);
       assertRate('1000/h', 1000, 3600);
       assertRate('5000/d', 5000, 86400);
+      assertRate(function(){return '5000/d';}, 5000, 86400);
     });
 
     it('has to be a valid format', function() {
@@ -109,6 +122,16 @@ describe('Options', function() {
           redis: {},
           key: 'ip',
           rate: '50/century'
+        });
+      }).should.throw('Invalid rate window: 50/century');
+    });
+
+    it('has to be a valid unit when passing a function to get the rate', function() {
+      (function() {
+        var opts = options.canonical({
+          redis: {},
+          key: 'ip',
+          rate: function(){return '50/century';}
         });
       }).should.throw('Invalid rate window: 50/century');
     });


### PR DESCRIPTION
@rprieto @nguyenchr @TabDigital/ping-api 

adding support to pass `rate/limit/window` as functions so the rate limit can be changed dynamically instead of needing a redeploy. this change is backwards compatible.