### PR TITLE
Allow incrementing by other than 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ You would typically specify a custom function:
 ```js
 // rate-limit based on the cost of an operation
 key: function(x) { return x.cost; }
+```
 
 ## HTTP middleware
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,19 @@ rate: '100/h'
 
 *Note:* the rate is parsed ahead of time, so this notation doesn't affect performance.
 
+### `incr`
+
+How much to increment the usage for a given call. This is useful in scenarios where incrementing by
+one is not the whole story.  For example, for rate limiting computation time.  Some operations take
+longer than other so counting operations doesn't work.  Rather, use `incr` to track and limit the
+actual compute time.
+
+You would typically specify a custom function:
+
+```js
+// rate-limit based on the cost of an operation
+key: function(x) { return x.cost; }
+
 ## HTTP middleware
 
 This package  contains a pre-built middleware,

--- a/lib/options.js
+++ b/lib/options.js
@@ -22,7 +22,12 @@ var getLimit = function(opts){
   return opts.limit;
 };
 
-var getWindow = function(opts){
+var getIncr = function (opts) {
+  if(typeof opts.incr === 'function') return opts.incr;
+  return opts.incr || 1;
+};
+
+var getWindow = function (opts) {
   if(getRate(opts)) return moment.duration(1, getMatches(opts)[2]) / 1000;
   if(typeof opts.window === 'function') return opts.window();
   return opts.window;
@@ -38,6 +43,7 @@ var validate = function(opts){
   assert.equal(typeof getKey(opts), 'function', 'Invalid key: ' + opts.key);
   if(opts.rate) assert.ok(getMatches(opts), 'Invalid rate: ' + getRate(opts));
   assert.equal(typeof getLimit(opts), 'number', 'Invalid limit: ' + getLimit(opts));
+  assert.equal(typeof getIncr(opts), 'function', 'Invalid incr: ' + opts.incr);
   assert.equal(typeof getWindow(opts), 'number', 'Invalid window: ' + getWindow(opts));
   assert.notEqual(getLimit(opts), 0,  'Invalid rate limit: ' + getRate(opts));
   assert.notEqual(getWindow(opts), 0, 'Invalid rate window: ' + getRate(opts));
@@ -50,6 +56,7 @@ canonical = function(opts) {
     key: getKey(opts),
     rate: getRate.bind(null, opts),
     limit: getLimit.bind(null, opts),
+    incr: getIncr.bind(null, opts),
     window: getWindow.bind(null, opts)
   };
 };

--- a/lib/rate-limiter.js
+++ b/lib/rate-limiter.js
@@ -4,12 +4,13 @@ module.exports = function(opts) {
   opts = options.canonical(opts);
   return function(request, callback) {
     var key = opts.key(request);
+    var incr = opts.incr(request);
     var tempKey = 'ratelimittemp:' + key;
     var realKey = 'ratelimit:' + key;
     opts.redis.multi()
          .setex(tempKey, opts.window(), 0)
          .renamenx(tempKey, realKey)
-         .incr(realKey)
+         .incrby(realKey, incr)
          .ttl(realKey)
          .exec(function(err, results) {
            if(err) {


### PR DESCRIPTION
This rate limiter is nice and simple.  Thanks for putting it together.  This PR allows the caller to spec an amount to increment the usage.  As noted in the readme, this is great for tracking variable things like compute time for operations.